### PR TITLE
Fix/navigation

### DIFF
--- a/app/src/main/java/com/example/marvel_app/feature_character/MainActivity.kt
+++ b/app/src/main/java/com/example/marvel_app/feature_character/MainActivity.kt
@@ -23,6 +23,21 @@ class MainActivity : AppCompatActivity() {
         navController = navHostFragment.navController
 
         val bottomNavigationView = findViewById<BottomNavigationView>(R.id.bottom_nav_main)
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+
+            when (destination.id) {
+                R.id.characterDetailFragment -> {
+                    val backStackEntry = navController.previousBackStackEntry
+                    val prevDestinationId = backStackEntry?.destination?.id
+                    when (prevDestinationId) {
+                        R.id.charactersFragment -> bottomNavigationView.menu.findItem(R.id.charactersFragment).isChecked = true
+                        R.id.favoriteCharactersFragment -> bottomNavigationView.menu.findItem(R.id.favoriteCharactersFragment).isChecked = true
+                    }
+                }
+                R.id.charactersFragment -> bottomNavigationView.menu.findItem(R.id.charactersFragment).isChecked = true
+                R.id.favoriteCharactersFragment -> bottomNavigationView.menu.findItem(R.id.favoriteCharactersFragment).isChecked = true
+            }
+        }
         bottomNavigationView.setupWithNavController(navController)
     }
 }

--- a/app/src/main/java/com/example/marvel_app/feature_character/data/local_database/CharacterDao.kt
+++ b/app/src/main/java/com/example/marvel_app/feature_character/data/local_database/CharacterDao.kt
@@ -13,7 +13,8 @@ interface CharacterDao {
 
     @Query("SELECT * FROM FavoriteCharacters WHERE name LIKE :searchName")
     fun searchFavoriteCharactersByName(searchName: String): List<FavoriteCharacterDatabaseDTO>
-
+    @Query("SELECT * FROM FavoriteCharacters WHERE id LIKE :id")
+    fun searchCharacterById(id:String):FavoriteCharacterDatabaseDTO
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertFavoriteCharacter(favoriteCharacterDatabaseDTO: FavoriteCharacterDatabaseDTO)
 

--- a/app/src/main/java/com/example/marvel_app/feature_character/data/repository/CharacterRepositoryImpl.kt
+++ b/app/src/main/java/com/example/marvel_app/feature_character/data/repository/CharacterRepositoryImpl.kt
@@ -39,6 +39,11 @@ class CharacterRepositoryImpl @Inject constructor(
            }
        }
 
+    override suspend fun isCharacterFavorited(id: String): Boolean =
+        withContext(Dispatchers.IO){
+            return@withContext characterDao.searchCharacterById(id) != null
+        }
+
 
     override suspend fun markAsFavoriteCharacter(character: Character) {
         withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/example/marvel_app/feature_character/domain/repository/CharacterRepository.kt
+++ b/app/src/main/java/com/example/marvel_app/feature_character/domain/repository/CharacterRepository.kt
@@ -7,6 +7,7 @@ interface CharacterRepository {
     suspend fun getDiscoverCharactersList(offset: Int,orderBy:String,name:String?): CharactersWrapper
     suspend fun getFavoriteCharactersList():List<Character>
     suspend fun searchFavoriteCharacters(name: String):List<Character>
+    suspend fun isCharacterFavorited(id: String):Boolean
     suspend fun markAsFavoriteCharacter(character: Character)
     suspend fun removeFavoriteCharacter(character: Character)
 }

--- a/app/src/main/java/com/example/marvel_app/feature_character/domain/use_cases/FavoriteCharacterUseCase.kt
+++ b/app/src/main/java/com/example/marvel_app/feature_character/domain/use_cases/FavoriteCharacterUseCase.kt
@@ -11,4 +11,8 @@ class FavoriteCharacterUseCase(
             repository.removeFavoriteCharacter(character)
         } else repository.markAsFavoriteCharacter(character)
     }
+
+    suspend fun isCharacterFavorited(character: Character):Boolean{
+        return repository.isCharacterFavorited(character.id)
+    }
 }

--- a/app/src/main/java/com/example/marvel_app/feature_character/presentation/character_detail/CharacterDetailFragment.kt
+++ b/app/src/main/java/com/example/marvel_app/feature_character/presentation/character_detail/CharacterDetailFragment.kt
@@ -26,7 +26,7 @@ class CharacterDetailFragment : BaseFragment<FragmentCharacterDetailBinding>() {
 
     private lateinit var favoriteMenuItem: MenuItem
 
-    val destinationChangedListener = NavController.OnDestinationChangedListener { controller, destination, arguments ->
+    private val destinationChangedListener = NavController.OnDestinationChangedListener { _, destination, _ ->
         when (destination.id) {
             R.id.characterDetailFragment ->
                 binding.toolbar.setNavigationIcon(R.drawable.arrow_back_24px)

--- a/app/src/main/java/com/example/marvel_app/feature_character/presentation/character_detail/CharacterDetailFragment.kt
+++ b/app/src/main/java/com/example/marvel_app/feature_character/presentation/character_detail/CharacterDetailFragment.kt
@@ -6,6 +6,7 @@ import android.view.MenuItem
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
+import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
@@ -24,6 +25,13 @@ class CharacterDetailFragment : BaseFragment<FragmentCharacterDetailBinding>() {
     private val characterDetailViewModel: CharacterDetailViewModel by viewModels()
 
     private lateinit var favoriteMenuItem: MenuItem
+
+    val destinationChangedListener = NavController.OnDestinationChangedListener { controller, destination, arguments ->
+        when (destination.id) {
+            R.id.characterDetailFragment ->
+                binding.toolbar.setNavigationIcon(R.drawable.arrow_back_24px)
+        }
+    }
     override fun onCreateBinding(inflater: LayoutInflater): FragmentCharacterDetailBinding {
         return FragmentCharacterDetailBinding.inflate(inflater)
     }
@@ -57,10 +65,16 @@ class CharacterDetailFragment : BaseFragment<FragmentCharacterDetailBinding>() {
         }
         val appBarConfiguration = AppBarConfiguration(navHostFragment.graph)
         toolbar.setupWithNavController(navHostFragment, appBarConfiguration)
-        toolbar.setNavigationIcon(R.drawable.arrow_back_24px)
+        binding.toolbar.setNavigationIcon(R.drawable.arrow_back_24px)
 
+        findNavController().addOnDestinationChangedListener(destinationChangedListener)
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        findNavController().removeOnDestinationChangedListener(destinationChangedListener)
+
+    }
     private fun setCharacterFavoriteIcon(character: Character) {
         if (character.isFavorited) {
             favoriteMenuItem.icon =

--- a/app/src/main/java/com/example/marvel_app/feature_character/presentation/character_detail/CharacterDetailFragment.kt
+++ b/app/src/main/java/com/example/marvel_app/feature_character/presentation/character_detail/CharacterDetailFragment.kt
@@ -15,6 +15,7 @@ import com.example.marvel_app.databinding.FragmentCharacterDetailBinding
 import com.example.marvel_app.feature_character.domain.models.Character
 import com.example.marvel_app.feature_character.presentation.BaseFragment
 import com.example.marvel_app.feature_character.presentation.ImageType
+import com.example.marvel_app.feature_character.presentation.ListStatus
 import com.example.marvel_app.feature_character.presentation.bindImage
 import com.example.marvel_app.feature_character.presentation.makeImageUrl
 import dagger.hilt.android.AndroidEntryPoint
@@ -26,12 +27,14 @@ class CharacterDetailFragment : BaseFragment<FragmentCharacterDetailBinding>() {
 
     private lateinit var favoriteMenuItem: MenuItem
 
-    private val destinationChangedListener = NavController.OnDestinationChangedListener { _, destination, _ ->
-        when (destination.id) {
-            R.id.characterDetailFragment ->
-                binding.toolbar.setNavigationIcon(R.drawable.arrow_back_24px)
+    private val destinationChangedListener =
+        NavController.OnDestinationChangedListener { _, destination, _ ->
+            when (destination.id) {
+                R.id.characterDetailFragment ->
+                    binding.toolbar.setNavigationIcon(R.drawable.arrow_back_24px)
+            }
         }
-    }
+
     override fun onCreateBinding(inflater: LayoutInflater): FragmentCharacterDetailBinding {
         return FragmentCharacterDetailBinding.inflate(inflater)
     }
@@ -54,7 +57,7 @@ class CharacterDetailFragment : BaseFragment<FragmentCharacterDetailBinding>() {
                     ImageType.DETAIL
                 )
             )
-
+            characterDetailViewModel.isCharacterFavorited()
             setCharacterFavoriteIcon(character)
 
             favoriteMenuItem.setOnMenuItemClickListener {
@@ -66,15 +69,31 @@ class CharacterDetailFragment : BaseFragment<FragmentCharacterDetailBinding>() {
         val appBarConfiguration = AppBarConfiguration(navHostFragment.graph)
         toolbar.setupWithNavController(navHostFragment, appBarConfiguration)
         binding.toolbar.setNavigationIcon(R.drawable.arrow_back_24px)
-
+        observeFavoriteStatus()
         findNavController().addOnDestinationChangedListener(destinationChangedListener)
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        findNavController().removeOnDestinationChangedListener(destinationChangedListener)
+    private fun observeFavoriteStatus() {
+        characterDetailViewModel.favoriteStatus.observe(viewLifecycleOwner) { favoriteStatus ->
+            when (favoriteStatus) {
+                ListStatus.LOADING -> {
+                    enableFavorite(false)
+                }
 
+                ListStatus.DONE -> {
+                    enableFavorite(true)
+                    characterDetailViewModel.character.value?.let { setCharacterFavoriteIcon(it) }
+
+                }
+
+                ListStatus.ERROR -> {}
+                else -> {}
+            }
+
+        }
     }
+
+
     private fun setCharacterFavoriteIcon(character: Character) {
         if (character.isFavorited) {
             favoriteMenuItem.icon =
@@ -83,5 +102,27 @@ class CharacterDetailFragment : BaseFragment<FragmentCharacterDetailBinding>() {
             favoriteMenuItem.icon =
                 ContextCompat.getDrawable(this.requireContext(), R.drawable.ic_star)
         }
+    }
+
+    private fun enableFavorite(enable: Boolean) {
+        val searchMenuItem = binding.toolbar.menu.findItem(R.id.favorite_item)
+
+        if (enable) {
+            searchMenuItem.apply {
+                isEnabled = true
+                icon?.alpha = 255
+            }
+        } else {
+            searchMenuItem.apply {
+                isEnabled = false
+                icon?.alpha = 130
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        findNavController().removeOnDestinationChangedListener(destinationChangedListener)
+
     }
 }

--- a/app/src/main/java/com/example/marvel_app/feature_character/presentation/character_detail/CharacterDetailViewModel.kt
+++ b/app/src/main/java/com/example/marvel_app/feature_character/presentation/character_detail/CharacterDetailViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.marvel_app.feature_character.domain.models.Character
 import com.example.marvel_app.feature_character.domain.use_cases.FavoriteCharacterUseCase
+import com.example.marvel_app.feature_character.presentation.ListStatus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,6 +19,9 @@ class CharacterDetailViewModel @Inject constructor(
 ): ViewModel() {
     private val _character=  MutableLiveData<Character>()
     val character: LiveData<Character> = _character
+
+    private val _favoriteStatus = MutableLiveData<ListStatus>()
+    val favoriteStatus: LiveData<ListStatus> = _favoriteStatus
 
     init {
         val navigationCharacter: Character? = savedStateHandle["character"]
@@ -35,6 +39,19 @@ class CharacterDetailViewModel @Inject constructor(
         }
     }
 
+    fun isCharacterFavorited(){
+        _favoriteStatus.value = ListStatus.LOADING
+        try {
+            viewModelScope.launch {
+                _character.value?.let {
+                    it.isFavorited = favoriteCharacterUseCase.isCharacterFavorited(it)
+                }
+                _favoriteStatus.value = ListStatus.DONE
+            }
+        }catch (e:Exception){
+            _favoriteStatus.value = ListStatus.ERROR
+        }
+    }
     fun onCharacterClicked(character: Character){
         _character.value = character
     }

--- a/app/src/main/java/com/example/marvel_app/feature_character/presentation/characters/CharactersFragment.kt
+++ b/app/src/main/java/com/example/marvel_app/feature_character/presentation/characters/CharactersFragment.kt
@@ -56,17 +56,19 @@ class CharactersFragment :
                         && !viewModel.charactersListEnded
                         && viewModel.discoverStatusMediator.value != ListStatus.LOADING
                     ) {
-                        viewModel.setCharactersList(adapter.itemCount)
+                        viewModel.charactersList.value?.let { viewModel.setCharactersList(it.size) }
                         binding.discoverGridRecyclerView.scrollToPosition(adapter.itemCount - 2)
 
                     } else if (viewModel.isSearchBarOpen.value == true
                         && !viewModel.searchedCharactersListEnded
                         && viewModel.searchStatusMediator.value != ListStatus.LOADING
                     ) {
-                        viewModel.searchCharacters(
-                            adapter.itemCount,
-                            marvelTopAppBar.marvelTopAppBarSearchText.text.toString()
-                        )
+                        viewModel.searchedCharacters.value?.let {
+                            viewModel.searchCharacters(
+                                it.size,
+                                marvelTopAppBar.marvelTopAppBarSearchText.text.toString()
+                            )
+                        }
                         binding.discoverGridRecyclerView.scrollToPosition(adapter.itemCount - 2)
                     }
 


### PR DESCRIPTION
Fix de alguns bugs que acontecia por navegação:
- Quando abria o mesmo detalhe de personagem no discover e no favorites, o icone de favorito não se mantinha atualizado pois era passado como parametro. Agora é uma request para a database local, mantendo a consistencia.

- Não entendi direito porque, mas quando entrava em um detalhe de personagem na discover, e depois clicava no icone da discover na bottom navigation, a seta para voltar do detalhe pra discover ficava o icone padrão, que é meio cinza, e não branco. Pelo que entendi isso é porque o Navigation UI entende qeu fiz uma navegação, mesmo não tendo saido do fragmento, e coloca o ícone padrão dele de voltar na backstack.

- Quando entrava no fragmento de detalhe pela discover, depois ia para o favorites e depois voltava para a o detalhe da discover, o icone da bottom navigation não ficava marcado.

- Havia a possibilidade de fazer duas requests com o mesmo offset na discover, isso porque o offset que eu estava passando era o tamanho do adapter. Portanto, se o adapter não foi atualizado, mas já é possível fazer uma nova request, acabava repetindo a mesma, mostrando personagens duplicados. Agora o offset é pelo tamanho da lista de personagens mesmo.